### PR TITLE
chore: upgrade Gemini model from 1.5-flash to 2.5-flash

### DIFF
--- a/server/src/constants/index.js
+++ b/server/src/constants/index.js
@@ -1,7 +1,7 @@
 const ENV = {
    PRODUCTION: "production",
    DEVELOPMENT: "development"
-};
+}
 
 const MODELS = {
   GEMINI_2_5_FLASH: "gemini-2.5-flash",

--- a/server/src/constants/index.js
+++ b/server/src/constants/index.js
@@ -1,6 +1,6 @@
 const ENV = {
-  PRODUCTION: "production",
-  DEVELOPMENT: "development",
+   PRODUCTION: "production",
+   DEVELOPMENT: "development"
 };
 
 const MODELS = {

--- a/server/src/constants/index.js
+++ b/server/src/constants/index.js
@@ -1,6 +1,10 @@
 const ENV = {
-   PRODUCTION: "production",
-   DEVELOPMENT: "development"
-}
+  PRODUCTION: "production",
+  DEVELOPMENT: "development",
+};
 
-export { ENV }
+const MODELS = {
+  GEMINI_2_5_FLASH: "gemini-2.5-flash",
+};
+
+export { ENV, MODELS };

--- a/server/src/constants/index.js
+++ b/server/src/constants/index.js
@@ -1,7 +1,7 @@
 const ENV = {
-   PRODUCTION: "production",
-   DEVELOPMENT: "development"
-}
+  PRODUCTION: "production",
+  DEVELOPMENT: "development",
+};
 
 const MODELS = {
   GEMINI_2_5_FLASH: "gemini-2.5-flash",

--- a/server/src/gemini/index.js
+++ b/server/src/gemini/index.js
@@ -1,12 +1,13 @@
 import dotenv from "dotenv";
 dotenv.config();
 
+import { MODELS } from "../constants/index.js";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI);
 
 async function getPredictionFromGeminiAI(input) {
-  const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+  const model = genAI.getGenerativeModel({ model: MODELS.GEMINI_2_5_FLASH });
   try {
     const result = await model.generateContent(input);
     const response = result.response;


### PR DESCRIPTION
### Summary
The Gemini 1.5-flash model has been deprecated. This PR upgrades our implementation to use Gemini 2.5-flash.

### Changes
- Updated `constants/index.js` to include `GEMINI_2_5_FLASH`.
- Updated Gemini integration in `gemini/index.js` to use 2.5-flash model.