### PR TITLE
feat(prediction_model): implement PredictionModel CRUD, route

### DIFF
--- a/server/src/controllers/predictionModel.controller.js
+++ b/server/src/controllers/predictionModel.controller.js
@@ -1,0 +1,119 @@
+import PredictionModel from "../models/predictionModel.js";
+import { myCache, catchErrors } from "../utils/index.js";
+
+const createPredictionModel = catchErrors(async (req, res) => {
+  const { owner, modelName, customName, status, type } = req.body;
+
+  if (!owner || !modelName || !customName || !status || !type)
+    throw new Error("Please provide owner and modelName");
+
+  const predictionModel = await PredictionModel.create({
+    owner,
+    modelName,
+    customName,
+    status,
+    type,
+  });
+
+  myCache.del("predictionModels");
+
+  return res.status(201).json({
+    success: true,
+    message: "Prediction model created successfully",
+    predictionModel,
+  });
+});
+
+const getAllPredictionModels = catchErrors(async (req, res) => {
+  const { modelName } = req.query;
+  const cacheKey = modelName
+    ? `predictionModel:${modelName.toLowerCase()}`
+    : "predictionModel:all";
+
+  const cachedModels = myCache.get(cacheKey);
+  if (cachedModels) {
+    return res.status(200).json({
+      success: true,
+      message: "Prediction models fetched successfully (from cache)",
+      predictionModels: cachedModels,
+    });
+  }
+
+  const query = {};
+  if (modelName) query.modelName = { $regex: modelName, $options: "i" };
+
+  const predictionModels = await PredictionModel.find(query).lean();
+  if (!predictionModels || predictionModels.length === 0) {
+    throw new Error("No prediction models found");
+  }
+
+  myCache.set(cacheKey, predictionModels);
+
+  return res.status(200).json({
+    success: true,
+    message: "Prediction models fetched successfully",
+    predictionModels,
+  });
+});
+
+const getPredictionModelById = catchErrors(async (req, res) => {
+  const { id } = req.params;
+
+  if (!id) throw new Error("Please provide prediction model ID");
+
+  const predictionModel = await PredictionModel.findById(id);
+
+  if (!predictionModel) throw new Error("Prediction model not found");
+
+  return res.status(200).json({
+    success: true,
+    message: "Prediction model fetched successfully",
+    predictionModel,
+  });
+});
+
+const updatePredictionModel = catchErrors(async (req, res) => {
+  const { id } = req.params;
+  const { owner, modelName, customName, status, type } = req.body;
+
+  if (!id) throw new Error("Please provide prediction model ID");
+
+  const predictionModel = await PredictionModel.findByIdAndUpdate(
+    id,
+    { owner, modelName, customName, status, type },
+    { new: true },
+  );
+
+  if (!predictionModel) throw new Error("Prediction model not found");
+
+  myCache.del("predictionModels");
+
+  return res.status(200).json({
+    success: true,
+    message: "Prediction model updated successfully",
+    predictionModel,
+  });
+});
+
+const deletePredictionModel = catchErrors(async (req, res) => {
+  const { id } = req.params;
+
+  if (!id) throw new Error("Please provide prediction model ID");
+
+  await PredictionModel.findByIdAndDelete(id);
+
+  myCache.del("predictionModels");
+
+  return res.status(200).json({
+    success: true,
+    message: "Prediction model deleted successfully",
+  });
+});
+
+export {
+  createPredictionModel,
+  getAllPredictionModels,
+  getPredictionModelById,
+  updatePredictionModel,
+  deletePredictionModel,
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -21,10 +21,12 @@ import {
   performance,
   recruitment,
   authentication,
+  predictionModel
 } from "./routes/index.routes.js";
 import { ENV } from "./constants/index.js";
 import { swaggerUi, swaggerSpec } from "./doc/index.js";
 // import {
+//   seedPredictionModels
 //   deleteAllPayrollRecords,
 //   generatePayrollDataForYear,
 //   generatePayrollDataForMonths,
@@ -84,6 +86,7 @@ cloudinary.v2.config({
 // deleteTodayAttendanceRecords()
 // generatePayrollDataForMonths(8)
 // generatePayrollDataForYear(2025)
+// seedPredictionModels();
 
 app.use("/api/roles", role);
 app.use("/api/leaves", leave);
@@ -97,6 +100,7 @@ app.use("/api/attendance", attendance);
 app.use("/api/departments", department);
 app.use("/api/performance", performance);
 app.use("/api/recruitment", recruitment);
+app.use("/api/prediction_models", predictionModel);
 
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 

--- a/server/src/models/predictionModel.js
+++ b/server/src/models/predictionModel.js
@@ -1,0 +1,25 @@
+import mongoose from "mongoose";
+
+const predictionModelSchema = new mongoose.Schema(
+  {
+    owner: { type: String, required: true },
+    modelName: { type: String, required: true },
+    customName: { type: String },
+    status: {
+      type: String,
+      enum: ["active", "disabled", "deprecated"],
+      default: "active",
+    },
+    type: { type: String },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const PredictionModel = mongoose.model(
+  "PredictionModel",
+  predictionModelSchema,
+);
+
+export default PredictionModel;

--- a/server/src/routes/index.routes.js
+++ b/server/src/routes/index.routes.js
@@ -10,6 +10,7 @@ import department from "./department.routes.js";
 import performance from "./performance.routes.js";
 import recruitment from "./recruitment.routes.js";
 import authentication from "./authentication.routes.js";
+import predictionModel from "./predictionModel.routes.js";
 
 export {
   role,
@@ -24,4 +25,5 @@ export {
   performance,
   recruitment,
   authentication,
+  predictionModel
 };

--- a/server/src/routes/predictionModel.routes.js
+++ b/server/src/routes/predictionModel.routes.js
@@ -1,0 +1,19 @@
+import express from "express";
+import {
+  createPredictionModel,
+  getAllPredictionModels,
+  getPredictionModelById,
+  updatePredictionModel,
+  deletePredictionModel,
+} from "../controllers/predictionModel.controller.js";
+import { verifyAdminToken } from "../middlewares/index.js";
+
+const router = express.Router();
+
+router.post("/", verifyAdminToken, createPredictionModel);
+router.get("/", verifyAdminToken, getAllPredictionModels);
+router.get("/:id", verifyAdminToken, getPredictionModelById);
+router.patch("/:id", verifyAdminToken, updatePredictionModel);
+router.delete("/:id", verifyAdminToken, deletePredictionModel);
+
+export default router;

--- a/server/src/seeders/index.js
+++ b/server/src/seeders/index.js
@@ -2,10 +2,11 @@ import Role from "../models/role.model.js";
 import Payroll from "../models/payroll.model.js";
 import { getMonthName } from "../utils/index.js";
 import Employee from "../models/employee.model.js";
+import Attendance from "../models/attendance.model.js";
 import Department from "../models/department.model.js";
 import Performance from "../models/performance.model.js";
+import PredictionModel from "../models/predictionModel.js";
 import { calculateAverageAttendance } from "../controllers/attendance.controller.js";
-import Attendance from "../models/attendance.model.js";
 
 const startHrmsApplication = async () => {
   try {
@@ -248,8 +249,41 @@ const alterEmployeeData = async () => {
   console.log("Altered");
 };
 
+const seedPredictionModels = async () => {
+  try {
+    const data = [
+      {
+        owner: "google",
+        modelName: "gemini-2.5-flash",
+        customName: "Gemini 2.5 Flash",
+        status: "active",
+        type: "generative",
+      },
+       {
+        owner: "google",
+        modelName: "gemini-1.5-flash",
+        customName: "Gemini 1.5 Flash",
+        status: "deprecated",
+        type: "generative",
+      },
+    ];
+
+    await PredictionModel.deleteMany({ modelName: "Gemini" });
+
+    const inserted = await PredictionModel.insertMany(data);
+
+    console.log("Seeded Prediction Models:", inserted);
+
+    console.log("MongoDB disconnected");
+  } catch (err) {
+    console.error("Seeder error:", err);
+    process.exit(1);
+  }
+};
+
 export {
   alterEmployeeData,
+  seedPredictionModels,
   startHrmsApplication,
   generatePerformanceData,
   deleteAllPayrollRecords,


### PR DESCRIPTION
## Description
This PR implements the complete **PredictionModel feature** in the backend, including:

1. **Mongoose Model** (`PredictionModel`)  
   - Fields: `owner`, `modelName`, `customName`, `status` (enum: active, disabled, deprecated), `type`, `createdAt`, `updatedAt`  
   - Tracks all available AI prediction models

2. **Controllers** (`predictionModel.controller.js`)  
   - `createPredictionModel` → Add a new prediction model  
   - `getAllPredictionModels` → Fetch all models (optional filter by modelName, with caching)  
   - `getPredictionModelById` → Fetch single model by ID  
   - `updatePredictionModel` → Update model details  
   - `deletePredictionModel` → Delete a model  
   - Follows same pattern as `Role` controllers with caching via `myCache` and `catchErrors`

3. **Routes** (`predictionModel.routes.js`)  
   - `POST /` → create  
   - `GET /` → fetch all  
   - `GET /:id` → fetch by ID  
   - `PATCH /:id` → update  
   - `DELETE /:id` → delete  
   - All routes protected by `verifyAdminToken` middleware

4. **Seeder** (`predictionModelSeeder.js`)  
   - Seeds **Gemini 2.5 Flash** AI model into the database  
   - Optional: removes existing Gemini entries to prevent duplicates  
   - Ready to extend for other models like `Grok` in the future  