### PR TITLE
fix: QR scanner overlay alignment on mobile and medium screens

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -87,11 +87,11 @@ body::-webkit-scrollbar,
   transition: 0.4s;
 }
 
-input:checked + .slider {
+input:checked+.slider {
   background-color: #4caf50;
 }
 
-input:checked + .slider:before {
+input:checked+.slider:before {
   transform: translateX(14px);
 }
 
@@ -103,9 +103,11 @@ td {
   0% {
     transform: translateY(0);
   }
+
   50% {
     transform: translateY(-2px);
   }
+
   100% {
     transform: translateY(0px);
   }
@@ -139,11 +141,13 @@ td {
 }
 
 @keyframes wave {
+
   0%,
   60%,
   100% {
     transform: scale(1);
   }
+
   30% {
     transform: scale(1.5);
   }
@@ -160,6 +164,7 @@ td {
     opacity: 0;
     transform: scale(0.8);
   }
+
   100% {
     opacity: 1;
     transform: scale(1);
@@ -181,15 +186,19 @@ td {
   0% {
     transform: rotate(0deg);
   }
+
   25% {
     transform: rotate(-10deg);
   }
+
   50% {
     transform: rotate(5deg);
   }
+
   75% {
     transform: rotate(-10deg);
   }
+
   100% {
     transform: rotate(0deg);
   }
@@ -197,18 +206,20 @@ td {
 
 .scan-overlay {
   position: absolute;
-  top: -30px;
-  left: 250px;
-  right: 0;
-  bottom: 110px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
+  border-radius: 12px;
   pointer-events: none;
 }
 
 .scan-line {
-  width: 230px;
+  width: 100%;
   height: 5px;
   border-radius: 100%;
   background-color: rgba(0, 255, 0, 0.7);
@@ -218,24 +229,20 @@ td {
 }
 
 @keyframes scanAnimation {
-  0% {
-    top: 29%;
-  }
-  50% {
-    top: 50%;
-  }
-  100% {
-    top: 70%;
-  }
+  0%   { top: 0%; }
+  50%  { top: 50%; }
+  100% { top: 100%; }
 }
 
 @keyframes glowEffect {
   0% {
     box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
   }
+
   50% {
     box-shadow: 0 0 18px rgba(0, 255, 0, 0.9);
   }
+
   100% {
     box-shadow: 0 0 8px rgba(0, 255, 0, 0.8);
   }
@@ -245,6 +252,7 @@ td {
   from {
     transform: translateX(100%);
   }
+
   to {
     transform: translateX(0);
   }
@@ -254,6 +262,7 @@ td {
   from {
     transform: translateX(0);
   }
+
   to {
     transform: translateX(100%);
   }
@@ -269,6 +278,7 @@ td {
     opacity: 0;
     transform: translateY(-10px);
   }
+
   100% {
     max-height: 500px;
     opacity: 1;
@@ -282,11 +292,13 @@ td {
     opacity: 0;
     transform: translateY(-20px);
   }
+
   50% {
     max-height: 300px;
     opacity: 0.5;
     transform: translateY(10px);
   }
+
   100% {
     max-height: 500px;
     opacity: 1;
@@ -300,11 +312,13 @@ td {
     opacity: 1;
     transform: translateY(0);
   }
+
   50% {
     max-height: 300px;
     opacity: 0.5;
     transform: translateY(10px);
   }
+
   100% {
     max-height: 0;
     opacity: 0;
@@ -317,10 +331,12 @@ td {
 }
 
 @keyframes wave {
+
   0%,
   100% {
     transform: translateY(0);
   }
+
   50% {
     transform: translateY(-10px);
   }


### PR DESCRIPTION
**Changes Made:**
- Removed hardcoded left: 250px, top: -30px, right: 0, bottom: 110px
- Added left: 0, top: 0, width: 100%, height: 100% for proper centering
- Updated .scan-line width from fixed 230px to 100% for responsiveness
- Updated @keyframes scanAnimation to animate from 0% to 100% of container height

**File Changed:**
> client/src/App.css